### PR TITLE
Add OneDrive & SharePoint upload capability

### DIFF
--- a/GraphSpy/static/js/functions.js
+++ b/GraphSpy/static/js/functions.js
@@ -141,6 +141,28 @@ function graphDownload(drive_id, item_id, access_token_id) {
     window.location = response_json["@microsoft.graph.downloadUrl"];
 }
 
+function graphUpload(path, file, access_token_id, callback) {
+    let formData = new FormData();
+    formData.append("file", file);
+    formData.append("upload_uri", "https://graph.microsoft.com/v1.0/me/drive/root:/" + path + "/" + file.name + ":/content");
+    formData.append("access_token_id", access_token_id);
+
+    $.ajax({
+        url: "/api/generic_graph_upload",
+        type: "POST",
+        data: formData,
+        processData: false,
+        contentType: false,
+        success: function(response) {
+            bootstrapToast("File Upload", "File uploaded successfully.", "success");
+            if (callback) callback();
+        },
+        error: function(xhr, status, error) {
+            bootstrapToast("File Upload", "Failed to upload file. Status code: " + xhr.status + ", Response: " + xhr.responseText, "danger");
+        }
+    });
+}
+
 // ========== Database ==========
 
 function deleteDatabase(database_name) {

--- a/GraphSpy/templates/OneDrive.html
+++ b/GraphSpy/templates/OneDrive.html
@@ -44,6 +44,34 @@
         </thead>
     </table>
 </div>
+
+<br>
+<h2>Upload a New File</h2>
+<form id="upload_form" class="row g-3" enctype="multipart/form-data">
+    <div>
+        <label for="file" class="form-label">Choose file to upload:</label>
+        <input type="file" id="file" name="file" class="form-control" required>
+    </div>
+    <div>
+        <input type="hidden" id="upload_access_token_id" name="access_token_id">
+        <input type="hidden" id="upload_path" name="path">
+        <button type="button" class="btn btn-primary" onclick="uploadFile()">Upload</button>
+    </div>
+</form>
+
+<script>
+    function uploadFile() {
+        var file = document.getElementById("file").files[0];
+        var path = document.getElementById("onedrive_form").path.value;
+        var access_token_id = document.getElementById("onedrive_form").access_token_id.value;
+
+        graphUpload(path, file, access_token_id, function() {
+            generateTable(); // Delay to ensure the file is uploaded
+        });
+    }
+</script>
+
+
 <script>
     generateTable();
     // Populate the response_table table


### PR DESCRIPTION
This PR adds the ability to upload files to OneDrive directly from the application:

Frontend:
Added a file upload section in OneDrive.html.
Created a form with file input and upload button.
Updated JavaScript to handle file uploads and refresh file list.

Backend:
Added /api/generic_graph_upload endpoint.
Implemented graph_upload_request function using Microsoft Graph API.

Testing:
Verified uploads with various files.
Ensured file list refreshes post-upload.

Additional Notes:
Utilises existing access token system for authentication.